### PR TITLE
Fix NPE on Root level types

### DIFF
--- a/lib/graphql.js
+++ b/lib/graphql.js
@@ -351,13 +351,17 @@ function schemaToGraph(parsedSchema) {
     });
 
 
-    let root_query = make_node(definitions['Query'], true, definitions);
-    root_query.name = root_query.name.toLowerCase();
-    queue.push(root_query);
+    if (definitions['Query']) {
+        let root_query = make_node(definitions['Query'], true, definitions);
+        root_query.name = root_query.name.toLowerCase();
+        queue.push(root_query);
+    }
 
-    let root_mutation = make_node(definitions['Mutation'], true, definitions);
-    root_mutation.name = root_mutation.name.toLowerCase();
-    queue.push(root_mutation);
+    if (definitions['Mutation']) {
+        let root_mutation = make_node(definitions['Mutation'], true, definitions);
+        root_mutation.name = root_mutation.name.toLowerCase();
+        queue.push(root_mutation);
+    }
 
     while (queue.length > 0) {
         let node = queue.shift();


### PR DESCRIPTION
If you provide a schema that does not have
either the Query or the Mutation root type
the script errors out.

This fix makes it so that it does not error
out. Instead it skips the missing type, or
if both types are missing, it will output
an empty entitlements map.